### PR TITLE
Chore(terraform): Default value update for identity_source to use Coo…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -463,7 +463,7 @@ variable "authorizer_definition_default" {
   default = {
     authorizer_name                  = null
     authorizer_uri                   = null
-    identity_source                  = "method.request.header.Authorization"
+    identity_source                  = "method.request.header.Cookie"
     identity_validation_expression   = null
     authorizer_result_ttl_in_seconds = 0
     authorizer_type                  = "REQUEST"


### PR DESCRIPTION
The New APIGw Authorizer requires the identity_source to be: method.request.header.Cookie instead of method.request.header.Authorization because the standard is to enforce HTTPOnly cookies for Serverless applications.