### PR TITLE
Fix/domain dependency

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 6.1.2
+module_version: 6.1.3
 
 test_defaults:
   runner_image: 851725245549.dkr.ecr.us-east-2.amazonaws.com/mdlz-spacelift:latest


### PR DESCRIPTION

issue is with the order of operations and dependencies for the API Gateway custom domain and base path mapping. The error occurs because the base path mapping is trying to be created before the custom domain name is fully created and available

---------------
https://mondelez-ctiso.app.spacelift.io/stack/ping-ping_mfa_reset-prod/run/01JSPSEAWADM3YCC4PZBNHV1DN


 Error: creating API Gateway Base Path Mapping (operation error API Gateway: CreateBasePathMapping, https response error StatusCode: 404, RequestID: b076dde7-d002-4d43-b55a-89e74ba7452e, NotFoundException: Invalid domain name identifier specified): api.ping.aws.mdlz.com/
│ 
│   with module.mfareset_api_gateway.aws_api_gateway_base_path_mapping.mapping["prod"],
│   on .terraform/modules/mfareset_api_gateway/main.tf line 68, in resource "aws_api_gateway_base_path_mapping" "mapping":
│   68: resource "aws_api_gateway_base_path_mapping" "mapping" {
│ 
╵
[01JSPSHAZKW64WBHYJG31ZRF9R] Unexpected exit code when applying changes: 1