### PR TITLE
fixing stage handling logic for prod

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 6.1.3
+module_version: 6.1.4
 
 test_defaults:
   runner_image: 851725245549.dkr.ecr.us-east-2.amazonaws.com/mdlz-spacelift:latest

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_api_gateway_base_path_mapping" "mapping" {
   for_each = { for stage in local.api_gateway_stages : stage.stage_name == "main" && var.remap_main_to_prod ? "prod" : stage.stage_name => stage if local.api_gateway.custom_domain != null }
 
   api_id      = aws_api_gateway_rest_api.default[local.api_gateway.name].id
-  stage_name  = each.key
+  stage_name  = each.key # This will be "prod" when main is remapped
   domain_name = local.api_gateway.custom_domain
   base_path   = each.key == "prod" ? "" : each.key
 
@@ -182,7 +182,7 @@ resource "aws_api_gateway_stage" "default" {
 
   rest_api_id           = aws_api_gateway_rest_api.default[local.api_gateway.name].id
   deployment_id         = aws_api_gateway_deployment.default[local.api_gateway.name].id
-  stage_name            = each.value["stage_name"]
+  stage_name            = each.key # This will be "prod" when main is remapped
   cache_cluster_enabled = each.value["cache_cluster_enabled"]
   cache_cluster_size    = each.value["cache_cluster_size"]
   client_certificate_id = each.value["client_certificate_id"] != null ? each.value["client_certificate_id"] : (local.api_gateway.client_cert_enabled ? aws_api_gateway_client_certificate.default[local.api_gateway.name].id : "")


### PR DESCRIPTION
There's a mismatch between the stage names in API Gateway module call and the base path mapping logic. Here's the problem:

When stage name is "main", The mapping tries to create a "prod" mapping (due to var.remap_main_to_prod being true), But the actual stage "prod" doesn't exist in API Gateway

remap_main_to_prod should be set as "true" since it results in cleaner production URLs like: https://api.ping.aws.mdlz.com/ instead of https://api.ping.aws.mdlz.com/main/


===========
https://mondelez-ctiso.app.spacelift.io/stack/ping-ping_mfa_reset-prod/run/01JSQ0HMT826SWJQME989R8JHW

│ Error: creating API Gateway Base Path Mapping (operation error API Gateway: CreateBasePathMapping, https response error StatusCode: 400, RequestID: 0391f139-7506-44a4-a909-0bd9dabdef50, BadRequestException: Invalid stage identifier specified): api.ping.aws.mdlz.com/
│ 
│   with module.mfareset_api_gateway.aws_api_gateway_base_path_mapping.mapping["prod"],
│   on .terraform/modules/mfareset_api_gateway/main.tf line 85, in resource "aws_api_gateway_base_path_mapping" "mapping":
│   85: resource "aws_api_gateway_base_path_mapping" "mapping" {